### PR TITLE
Instruction Address and code coverage change.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ WORKDIR root
 
 COPY . .
 
-RUN cmake -B build -DCMAKE_BUILD_TYPE=Debug
+RUN cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-coverage"
 RUN make -C./build
 
 RUN ./build/src/test/Disassembler_TEST
@@ -27,3 +27,5 @@ RUN scripts/elfLinuxBuildAndRun.sh src/test/hello.linux.asm \
 
 RUN export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$XED_LIB_PATH \
     && ./build/src/cli/disasm --binary -f src/test/hello.linux.out -d build/plugins/xedPlugin/libxedPlugin.so
+
+RUN scripts/runGcov.sh

--- a/plugins/xedPlugin/test/test.cpp
+++ b/plugins/xedPlugin/test/test.cpp
@@ -8,12 +8,11 @@ TEST_CASE("test 2 instructions") {
   unsigned char assembly[] = "\x55\x48\x8b\x05\xb8\x13\x00\x00";
   XedDisassembler disasm(Archtype::X86_64);
   disasm.Decode(assembly, sizeof(assembly) - 1);
-  auto operands = disasm.getOperands();
-  auto opCodes = disasm.getOpCodes();
-  REQUIRE(opCodes[0] == "pushq");
-  REQUIRE(operands[0] == "%rbp");
-  REQUIRE(opCodes[1] == "movq");
-  REQUIRE(operands[1] == "0x13b8(%rip), %rax");
+  auto instructions = disasm.getInstructions();
+  REQUIRE(instructions[0].opcode == "pushq");
+  REQUIRE(instructions[0].operandsStr == "%rbp");
+  REQUIRE(instructions[1].opcode == "movq");
+  REQUIRE(instructions[1].operandsStr == "0x13b8(%rip), %rax");
 }
 
 TEST_CASE("test more instructions") {

--- a/plugins/xedPlugin/xedDisassembler.cpp
+++ b/plugins/xedPlugin/xedDisassembler.cpp
@@ -1,5 +1,6 @@
 #include <iostream>
 
+#include "instruction.h"
 #include "xedDisassembler.h"
 
 extern "C" {
@@ -94,12 +95,10 @@ int XedDisassembler::decodeInstruction(const unsigned char *code) {
       continue;
     }
     std::string instruction = ::printInstruction(code, &xedd);
-    // std::cout << instruction << std::endl;
     size_t split = instruction.find(' ');
     std::string opcode = instruction.substr(0, split);
     std::string strOperands = ::trim(instruction.substr(split + 1));
-    operands.push_back(strOperands);
-    opCodes.push_back(opcode);
+    instructions.push_back(Instruction(0, opcode, strOperands));
     return currByte;
   }
   return -1;
@@ -112,6 +111,13 @@ void XedDisassembler::Decode(const unsigned char *code, size_t size) {
     size_t count = decodeInstruction(currInst);
     if (count == -1) {
       break;
+    }
+
+    // NOTE: this will work if we are printing out all the instructions
+    // it will breakdown after the per function disassemble feature.
+    // TODO investigate how to get instruction address using XED
+    if (instructions.size() > 0) {
+      instructions[instructions.size() - 1].address = currCount;
     }
     currInst += count;
     currCount += count;

--- a/plugins/xedPlugin/xedLibInterface.cpp
+++ b/plugins/xedPlugin/xedLibInterface.cpp
@@ -1,4 +1,5 @@
 #include "../dataPattern/singleton.h"
+#include "instruction.h"
 #include "libInterface.h"
 #include "xedDisassembler.h"
 #include <iostream>
@@ -44,24 +45,14 @@ EXPORT(void) Clear() {
   instance.pXedDisassembler->Clear();
 }
 
-EXPORT(const std::vector<std::string> *) GetOperands() {
+EXPORT(const std::vector<Instruction> *) GetInstructions() {
   auto &instance = Singleton::get();
   auto lock(instance.getLock());
   if (instance.pXedDisassembler == nullptr) {
     std::cerr << "XedDisassembler is not Initalize!" << std::endl;
     return nullptr;
   }
-  return &(instance.pXedDisassembler->getOperands());
-}
-
-EXPORT(const std::vector<std::string> *) GetOpCodes() {
-  auto &instance = Singleton::get();
-  auto lock(instance.getLock());
-  if (instance.pXedDisassembler == nullptr) {
-    std::cerr << "XedDisassembler is not Initalize!" << std::endl;
-    return nullptr;
-  }
-  return &(instance.pXedDisassembler->getOpCodes());
+  return &(instance.pXedDisassembler->getInstructions());
 }
 
 EXPORT(void) Initalize(Archtype archType) {

--- a/scripts/clang-format.sh
+++ b/scripts/clang-format.sh
@@ -1,2 +1,1 @@
-find src/ \( -name \*.h -o -name \*.cpp \) -exec clang-format -style=file -i {} \;
-find plugins/ \( -name \*.h -o -name \*.cpp \) -exec clang-format -style=file -i {} \;
+find src plugins \( -name \*.h -o -name \*.cpp \) -exec clang-format -style=file -i {} \;

--- a/scripts/runGcov.sh
+++ b/scripts/runGcov.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+export CODECOV_TOKEN="d9c30fc8-86aa-42df-9194-25dfe3f9a408"
+find src plugins \( -name \*.h -o -name \*.cpp \) -exec gcov -style=file -i build/{} \;
+bash <(curl -s https://codecov.io/bash)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -73,6 +73,10 @@ set(HeaderFiles
     disassemble.h
     dynamicDisassembler.h
     parser.h
+    interfaces/helpers.h
+    interfaces/instruction.h
+    interfaces/types.h
+    interfaces/interfaceDisassembler.h
 )
 
 add_library(${PROJECT_NAME} STATIC ${SourceFiles} ${HeaderFiles}

--- a/src/capstoneDisassembler.cpp
+++ b/src/capstoneDisassembler.cpp
@@ -1,6 +1,6 @@
 #include "capstoneDisassembler.h"
+#include "interfaces/instruction.h"
 #include <capstone/capstone.h>
-
 struct platform {
   cs_arch arch;
   cs_mode mode;
@@ -44,8 +44,8 @@ void CapstoneDisassembler::Decode(const unsigned char *code, size_t size) {
   size_t count = decodeInstruction(code, size, insn);
   if (count > 0) {
     for (size_t i = 0; i < count; i++) {
-      opCodes.push_back(insn[i].mnemonic);
-      operands.push_back(insn[i].op_str);
+      instructions.push_back(
+          Instruction(insn[i].address, insn[i].mnemonic, insn[i].op_str));
     }
   }
   freeInstruction(insn, count);

--- a/src/disassemble.h
+++ b/src/disassemble.h
@@ -1,6 +1,7 @@
 #ifndef __Disassembler_H__
 #define __Disassembler_H__
 
+#include "interfaces/instruction.h"
 #include "interfaces/interfaceDisassembler.h"
 #include <iostream>
 #include <iterator>
@@ -17,13 +18,8 @@ public:
   virtual void Decode(const unsigned char *code, size_t size) final;
   virtual ~Disassembler() {}
   friend std::ostream &operator<<(std::ostream &out, const Disassembler &aDis);
-  // const std::unique_ptr<AbstractDisassembler>& getDisassembler() const {
-  // return pDisasm;}
-  const std::vector<std::string> &getOperands() const final {
-    return pDisasm->getOperands();
-  }
-  const std::vector<std::string> &getOpCodes() const final {
-    return pDisasm->getOpCodes();
+  const std::vector<Instruction> &getInstructions() const final {
+    return pDisasm->getInstructions();
   }
   virtual void Clear() final;
 
@@ -42,13 +38,20 @@ inline std::ostream &operator<<(std::ostream &out, const std::vector<T> &v) {
 }
 
 inline std::ostream &operator<<(std::ostream &out, const Disassembler &aDis) {
-  auto operands = aDis.pDisasm->getOperands();
-  auto opCodes = aDis.pDisasm->getOpCodes();
-  out << "Instruction count: " << opCodes.size() << std::endl;
-  for (size_t i = 0; i < opCodes.size(); i++) {
-    out << opCodes[i] << " " << operands[i] << std::endl;
+  if (aDis.pDisasm.get()) {
+    out << *(aDis.pDisasm.get()) << std::endl;
   }
   return out;
 }
+
+/*inline std::ostream &operator<<(std::ostream &out,
+                                const Disassembler &aDis) {
+  auto instructions = aDis.pDisasm->getInstructions();
+  out << "Instruction count: " << instructions.size() << std::endl;
+  for (size_t i = 0; i < instructions.size(); i++) {
+    out << instructions[i] << std::endl;
+  }
+  return out;
+}*/
 
 #endif // __Disassembler_H__

--- a/src/dynamicDisassembler.cpp
+++ b/src/dynamicDisassembler.cpp
@@ -13,8 +13,7 @@ DynamicDisassembler::~DynamicDisassembler() {
 void DynamicDisassembler::Decode(const unsigned char *code, size_t size) {
   DynamicLibMgr::decode(code, size);
   AbstractDisassembler::Clear();
-  DynamicLibMgr::getOperands(operands);
-  DynamicLibMgr::getOpCodes(opCodes);
+  DynamicLibMgr::getInstructions(instructions);
 }
 
 void DynamicDisassembler::Clear() { DynamicLibMgr::clear(); }

--- a/src/interfaces/helpers.h
+++ b/src/interfaces/helpers.h
@@ -2,21 +2,49 @@
 #ifndef __helper_h__
 #define __helper_h__
 
+#include <algorithm>
+#include <cctype>
+#include <functional>
+#include <locale>
 #include <sstream>
 #include <string>
 #include <vector>
 
 class StringHelpers {
 public:
-  static void Split(const std::string &input,
-                    std::vector<std::string> &result) {
+  typedef std::function<void(std::string &s)> stringFunc;
+  static void Split(const std::string &input, std::vector<std::string> &result,
+                    std::function<void(std::string &s)> fn = doNothing) {
     result.clear();
     std::stringstream s_stream(input); // create string stream from the string
     while (s_stream.good()) {
       std::string substr;
       getline(s_stream, substr, ','); // get first string delimited by comma
+      fn(substr);
       result.push_back(substr);
     }
+  }
+  static inline void doNothing(std::string &) {}
+
+  // trim from start (in place)
+  static inline void ltrim(std::string &s) {
+    s.erase(s.begin(), std::find_if(s.begin(), s.end(), [](unsigned char ch) {
+              return !std::isspace(ch);
+            }));
+  }
+
+  // trim from end (in place)
+  static inline void rtrim(std::string &s) {
+    s.erase(std::find_if(s.rbegin(), s.rend(),
+                         [](unsigned char ch) { return !std::isspace(ch); })
+                .base(),
+            s.end());
+  }
+
+  // trim from both ends (in place)
+  static inline void trim(std::string &s) {
+    ltrim(s);
+    rtrim(s);
   }
 
 private:

--- a/src/interfaces/instruction.h
+++ b/src/interfaces/instruction.h
@@ -1,0 +1,29 @@
+#ifndef __INSTRUCTION_H__
+#define __INSTRUCTION_H__
+
+#include "helpers.h"
+#include <iomanip>
+#include <string>
+#include <vector>
+
+struct Instruction {
+  uint64_t address;
+  std::string opcode;
+  std::string operandsStr;
+  std::vector<std::string> operands;
+  Instruction(uint64_t address, std::string opcode, std::string operandsStr)
+      : address(address), opcode(opcode), operandsStr(operandsStr) {
+    using namespace std::placeholders;
+    StringHelpers::stringFunc trim = std::bind(StringHelpers::trim, _1);
+    StringHelpers::Split(operandsStr, operands, trim);
+  }
+};
+
+inline std::ostream &operator<<(std::ostream &out,
+                                const Instruction &instruction) {
+  out << std::left << "0x" << std::setw(8) << std::hex << instruction.address
+      << std::setw(9) << instruction.opcode << instruction.operandsStr;
+  return out;
+}
+
+#endif // __INSTRUCTION_H__

--- a/src/interfaces/interfaceDisassembler.h
+++ b/src/interfaces/interfaceDisassembler.h
@@ -1,7 +1,9 @@
 #ifndef __Interface_Disassembler_H__
 #define __Interface_Disassembler_H__
 
+#include "instruction.h"
 #include "types.h"
+#include <iomanip>
 #include <iostream>
 #include <iterator>
 #include <string>
@@ -12,8 +14,7 @@ public:
   virtual void Decode(const unsigned char *code, size_t size) = 0;
   virtual void Clear() = 0;
   virtual ~InterfaceDisassembler(){};
-  virtual const std::vector<std::string> &getOperands() const = 0;
-  virtual const std::vector<std::string> &getOpCodes() const = 0;
+  virtual const std::vector<Instruction> &getInstructions() const = 0;
 };
 
 class AbstractDisassembler : public InterfaceDisassembler {
@@ -21,26 +22,25 @@ public:
   virtual ~AbstractDisassembler() {}
   friend std::ostream &operator<<(std::ostream &out,
                                   const AbstractDisassembler &aDis);
-  virtual const std::vector<std::string> &getOperands() const {
-    return operands;
-  }
-  virtual const std::vector<std::string> &getOpCodes() const { return opCodes; }
-  virtual void Clear() {
-    operands.clear();
-    opCodes.clear();
+
+  virtual const std::vector<Instruction> &getInstructions() const {
+    return instructions;
   }
 
+  virtual void Clear() { instructions.clear(); }
+
 protected:
-  std::vector<std::string> operands;
-  std::vector<std::string> opCodes;
+  std::vector<Instruction> instructions;
 };
 
 inline std::ostream &operator<<(std::ostream &out,
                                 const AbstractDisassembler &aDis) {
-  auto operands = aDis.operands;
-  auto opCodes = aDis.opCodes;
-  for (size_t i = 0; i < aDis.opCodes.size(); i++) {
-    out << opCodes[i] << " " << operands[i] << std::endl;
+  auto instructions = aDis.instructions;
+  out << "Instruction count: " << instructions.size() << std::endl;
+  out << "address | opcode | operands" << std::endl;
+  out << "---------------------------" << std::endl;
+  for (size_t i = 0; i < instructions.size(); i++) {
+    out << instructions[i] << std::endl;
   }
   return out;
 }

--- a/src/interfaces/libInterface.h
+++ b/src/interfaces/libInterface.h
@@ -1,6 +1,7 @@
 #ifndef __lib_Interface_H__
 #define __lib_Interface_H__
 
+#include "instruction.h"
 #include "interfaceDisassembler.h"
 #include "types.h"
 #include <memory>
@@ -14,8 +15,7 @@
 EXPORT(AbstractDisassembler *) GetDisassembler();
 EXPORT(void) Decode(const unsigned char *code, size_t size);
 EXPORT(void) Clear();
-EXPORT(const std::vector<std::string> *) GetOperands();
-EXPORT(const std::vector<std::string> *) GetOpCodes();
+EXPORT(const std::vector<Instruction> *) GetInstructions();
 EXPORT(void) Initalize(Archtype archType);
 EXPORT(bool) IsInitalized();
 

--- a/src/pluginInfra/dynamicLibMgr.cpp
+++ b/src/pluginInfra/dynamicLibMgr.cpp
@@ -27,9 +27,9 @@ Singleton_DynamicLibMgr_Members::Singleton_DynamicLibMgr_Members() {}
 
 typedef SingletonBase<Singleton_DynamicLibMgr_Members> Singleton;
 
-const char *arrDylibFunctionNames[] = {
-    "Initalize", "IsInitalized", "GetDisassembler", "Decode",
-    "Clear",     "GetOperands",  "GetOpCodes"};
+const char *arrDylibFunctionNames[] = {"Initalize",       "IsInitalized",
+                                       "GetDisassembler", "Decode",
+                                       "Clear",           "GetInstructions"};
 
 function_union *Singleton_DynamicLibMgr_Members::getFunctions(
     const std::string &sChosenDylibPath) {
@@ -160,24 +160,13 @@ void DynamicLibMgr::clear() {
   dylibFunctions->by_type.Clear();
 }
 
-void DynamicLibMgr::getOperands(std::vector<std::string> &operands) {
+void DynamicLibMgr::getInstructions(std::vector<Instruction> &instructions) {
   auto &instance = Singleton::get();
   auto lock(instance.getLock());
   function_union *dylibFunctions = instance.getFunctions();
   assert(dylibFunctions != nullptr);
-  auto libOperands = dylibFunctions->by_type.GetOperands();
-  if (libOperands) {
-    operands.assign(libOperands->begin(), libOperands->end());
-  }
-}
-
-void DynamicLibMgr::getOpCodes(std::vector<std::string> &opCodes) {
-  auto &instance = Singleton::get();
-  auto lock(instance.getLock());
-  function_union *dylibFunctions = instance.getFunctions();
-  assert(dylibFunctions != nullptr);
-  auto libOpCodes = dylibFunctions->by_type.GetOpCodes();
-  if (libOpCodes) {
-    opCodes.assign(libOpCodes->begin(), libOpCodes->end());
+  auto libInstructions = dylibFunctions->by_type.GetInstructions();
+  if (libInstructions) {
+    instructions.assign(libInstructions->begin(), libInstructions->end());
   }
 }

--- a/src/pluginInfra/dynamicLibMgr.h
+++ b/src/pluginInfra/dynamicLibMgr.h
@@ -8,6 +8,7 @@
 #define CALL_CONV
 #endif
 
+#include "interfaces/instruction.h"
 #include "interfaces/types.h"
 #include <memory>
 
@@ -20,10 +21,9 @@ typedef struct disasmImpl {
   AbstractDisassembler *(*GetDisassembler)();
   void (*Decode)(const unsigned char *, size_t);
   void (*Clear)();
-  const std::vector<std::string> *(*GetOperands)();
-  const std::vector<std::string> *(*GetOpCodes)();
+  const std::vector<Instruction> *(*GetInstructions)();
 
-  static const int NUM_FUNCTIONS = 7;
+  static const int NUM_FUNCTIONS = 6;
 } disasmImpl;
 
 typedef union {
@@ -46,8 +46,7 @@ public:
   static AbstractDisassembler *getDisassembler();
   static void decode(const unsigned char *code, size_t size);
   static void clear();
-  static void getOperands(std::vector<std::string> &operands);
-  static void getOpCodes(std::vector<std::string> &opCodes);
+  static void getInstructions(std::vector<Instruction> &instructions);
 };
 
 #endif // __Dynamic_Lib_Mgr_H__

--- a/src/test/test.cpp
+++ b/src/test/test.cpp
@@ -8,12 +8,11 @@ TEST_CASE("test 2 instructions") {
   unsigned char assembly[] = "\x55\x48\x8b\x05\xb8\x13\x00\x00";
   Disassembler disasm(Archtype::X86_64, DisassemblerType::CAPSTONE);
   disasm.Decode(assembly, sizeof(assembly) - 1);
-  auto operands = disasm.getOperands();
-  auto opCodes = disasm.getOpCodes();
-  REQUIRE(opCodes[0] == "push");
-  REQUIRE(operands[0] == "rbp");
-  REQUIRE(opCodes[1] == "mov");
-  REQUIRE(operands[1] == "rax, qword ptr [rip + 0x13b8]");
+  auto instructions = disasm.getInstructions();
+  REQUIRE(instructions[0].opcode == "push");
+  REQUIRE(instructions[0].operandsStr == "rbp");
+  REQUIRE(instructions[1].opcode == "mov");
+  REQUIRE(instructions[1].operandsStr == "rax, qword ptr [rip + 0x13b8]");
 }
 
 TEST_CASE("test more instructions") {


### PR DESCRIPTION
create an instruction struct. Carry around a single vector going forward. Couple addresses with opcodes and operands. Add support for printing addresses

resolves #23
resolves #22
